### PR TITLE
Refactored image uploads and processing.

### DIFF
--- a/frontend/views.py
+++ b/frontend/views.py
@@ -5,8 +5,10 @@ from django.shortcuts import get_object_or_404, render_to_response
 from django.template import RequestContext
 from django.utils import timezone
 
-from photos.models import Album, Photo, PendingPhoto
+from photos.models import Album, Photo, PendingPhoto, AlbumMember
 from photos import image_uploads
+from photos_api import device_push
+
 
 def index(request):
     if request.user.is_authenticated():
@@ -42,20 +44,29 @@ def album(request, pk):
 
     if request.POST:
         if 'add_photos' in request.POST:
-            photo_ids = []
+            pending_photos = []
             for f in request.FILES.getlist('photo_files'):
-                photo_id = Photo.objects.upload_request(request.user)
-                pending_photo = PendingPhoto.objects.get(photo_id=photo_id)
+
+                pending_photo = PendingPhoto.objects.create(author=request.user)
                 location, directory = pending_photo.bucket.split(':')
                 if location != 'local':
                     raise ValueError('Unknown photo bucket location: ' + location)
 
-                image_uploads.handle_file_upload(directory, photo_id, f.chunks())
-                photo_ids.append(photo_id)
+                image_uploads.handle_file_upload(directory, pending_photo.photo_id, f.chunks())
+                pending_photos.append(pending_photo)
                 num_photos_added += 1
 
-            if photo_ids:
-                album.add_photos(request.user, photo_ids)
+            # Upload pending photos
+            photos = [pf.get_or_process_uploaded_image_and_create_photo(album) for pf in pending_photos]
+
+            # Send push notifications to the album members about just added photos
+            device_push.broadcast_photos_added(
+                album_id=album.id,
+                author_id=request.user.id,
+                album_name=album.name,
+                author_name=request.user.nickname,
+                num_photos=len(photos),
+                user_ids=[membership.user.id for membership in AlbumMember.objects.filter(album=album).only('user__id')])
 
     data = {
             'album': album,

--- a/photos/models.py
+++ b/photos/models.py
@@ -98,20 +98,6 @@ class Album(models.Model):
     def get_etag(self):
         return u'{0}'.format(self.revision_number)
 
-    def add_photos(self, author, photo_ids):
-        now = timezone.now()
-        for photo_id in photo_ids:
-            # TODO Catch exception
-            Photo.objects.upload_to_album(photo_id, self, now)
-
-        device_push.broadcast_photos_added(
-                album_id = self.id,
-                author_id = author.id,
-                album_name = self.name,
-                author_name = author.nickname,
-                num_photos = len(photo_ids),
-                user_ids = [membership.user.id for membership in AlbumMember.objects.filter(album=self).only('user__id')])
-
     def get_member_users(self):
         return [membership.user for membership in AlbumMember.objects.filter(album=self).only('user')]
 
@@ -138,57 +124,10 @@ all_photo_buckets = (
         'local:photos04',
         )
 
+
 class PhotoManager(models.Manager):
-    def upload_request(self, author):
-        success = False
-        while not success:
-            new_id = Photo.generate_photo_id()
+    pass
 
-            new_pending_photo = PendingPhoto.objects.create(
-                    photo_id = new_id,
-                    bucket = random.choice(all_photo_buckets),
-                    start_time = timezone.now(),
-                    author = author
-                    )
-
-            # Make sure that there is no existing Photo with the same id
-
-            if not Photo.objects.filter(photo_id=new_id).exists():
-                success = True
-            else:
-                new_pending_photo.delete()
-
-        return new_id
-
-    def upload_to_album(self, photo_id, album, date_created):
-        try:
-            return Photo.objects.get(photo_id=photo_id)
-        except Photo.DoesNotExist:
-            pass
-
-        try:
-            pending_photo = PendingPhoto.objects.get(photo_id=photo_id)
-        except PendingPhoto.DoesNotExist:
-            # TODO Better exception
-            raise
-
-        # TODO catch exception:
-        width, height = image_uploads.process_uploaded_image(pending_photo.bucket, photo_id)
-
-        new_photo = Photo.objects.create(
-                photo_id=photo_id,
-                bucket=pending_photo.bucket,
-                date_created=date_created,
-                author=pending_photo.author,
-                album=album,
-                width=width,
-                height=height)
-
-        pending_photo.delete()
-
-        album.save_revision(date_created)
-
-        return new_photo
 
 class Photo(models.Model):
     photo_id = models.CharField(primary_key=True, max_length=128)
@@ -233,8 +172,54 @@ class Photo(models.Model):
         image_dimensions_calculator = image_uploads.image_sizes[image_size_str]
         return image_dimensions_calculator.get_image_dimensions(self.width, self.height)
 
+def get_pending_photo_default_photo_id():
+    photo_id_generated = False
+    photo_id = None
+    while not photo_id_generated:
+        photo_id = Photo.generate_photo_id()
+        # Make sure that there is no existing Photo with the same id
+        if Photo.objects.filter(pk=photo_id).exists():
+            continue
+        photo_id_generated = True
+    return photo_id
+
+def get_pending_photo_default_bucket():
+    return random.choice(all_photo_buckets)
+
 class PendingPhoto(models.Model):
-    photo_id = models.CharField(primary_key=True, max_length=128)
-    bucket = models.CharField(max_length=64)
-    start_time = models.DateTimeField()
+    photo_id = models.CharField(primary_key=True, max_length=128, default=get_pending_photo_default_photo_id)
+    bucket = models.CharField(max_length=64, choices=zip(all_photo_buckets, all_photo_buckets),
+                              default=get_pending_photo_default_bucket)
+    start_time = models.DateTimeField(default=timezone.now)
     author = models.ForeignKey(settings.AUTH_USER_MODEL)
+
+    def get_or_process_uploaded_image_and_create_photo(self, album, date_created):
+        """
+        For already uploaded photos it will simply return photo.
+        For pending photo it will process uploaded image, create Photo object and return it.
+        """
+        try:
+            photo = Photo.objects.get(photo_id=self.photo_id)
+        except Photo.DoesNotExist:
+            pass
+        else:
+            return photo
+
+        # TODO catch exception:
+        width, height = image_uploads.process_uploaded_image(self.bucket, self.photo_id)
+
+        new_photo = Photo.objects.create(
+            photo_id=self.photo_id,
+            bucket=self.bucket,
+            date_created=date_created,
+            author=self.author,
+            album=album,
+            width=width,
+            height=height
+        )
+
+        self.delete()
+
+        album.save_revision(date_created)
+
+        return new_photo

--- a/photos_api/views.py
+++ b/photos_api/views.py
@@ -5,6 +5,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.core.files import File
+from photos_api import device_push
 
 from rest_framework import generics
 from rest_framework.decorators import api_view, permission_classes
@@ -95,7 +96,21 @@ class AlbumDetail(generics.RetrieveAPIView):
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         if serializer.object.add_photos:
-            self.album.add_photos(request.user, serializer.object.add_photos)
+            now = timezone.now()
+
+            # Upload pending photos. For photos that already uploaded this will simply return photo
+            pending_photos = PendingPhoto.objects.filter(photo_id__in=serializer.object.add_photos)
+            photos = [pf.get_or_process_uploaded_image_and_create_photo(self.album, now) for pf in pending_photos]
+
+            # Send push notifications to the album members about just added photos
+            device_push.broadcast_photos_added(
+                album_id=self.album.id,
+                author_id=request.user.id,
+                album_name=self.album.name,
+                author_name=request.user.nickname,
+                num_photos=len(photos),
+                user_ids=[membership.user.id for membership in AlbumMember.objects.filter(album=self.album).only('user__id')])
+
 
         add_member_ids = []
         add_member_phones = []
@@ -202,8 +217,9 @@ class Albums(generics.ListAPIView):
             else:
                 # TODO Add members from phone number
                 pass
-        for photo_id in serializer.object.photos:
-            Photo.objects.upload_to_album(photo_id, album, now)
+
+        for pending_photo in PendingPhoto.objects.filter(photo_id__in=serializer.object.photos):
+            pending_photo.get_or_process_uploaded_image_and_create_photo(album, now)
 
         responseSerializer = AlbumSerializer(album)
         return Response(responseSerializer.data)
@@ -219,10 +235,10 @@ def photos_upload_request(request, format=None):
 
     response_data = []
     for i in xrange(num_photos):
-        photo_id = Photo.objects.upload_request(request.user)
+        pending_photo = PendingPhoto.objects.create(author=request.user)
         response_data.append({
-            'photo_id': photo_id,
-            'upload_url': reverse('photo-upload', [photo_id], request=request)
+            'photo_id': pending_photo.photo_id,
+            'upload_url': reverse('photo-upload', [pending_photo.photo_id], request=request)
             })
 
     return Response(response_data)


### PR DESCRIPTION
Here are some highlights:
- Removed method `Album.add_photos`. It has nothing to do with "add photos" and model in general. This method runs `Photo.objects.upload_to_album` and sends push notification. This job should be done by Controller not a model, especially `Album` in this case.
- Removed `PhotoManager.upload_request`. All this method does is it creates a new `PendingPhoto` and ensures uniquenes of `photo_id`. It has nothing to do with `Photo` model and especially with its `Manager`. Just use `PendingPhoto.objects.create(author=someone)` instead.
- Removed `PhotoManager.upload_to_album`. This functionality added as a method on `PendingPhoto`. But I think functionality of this method should be moved to the controller. 
